### PR TITLE
fixed problems running VS2017 enterprise version on win 10x64

### DIFF
--- a/VS2017ComCmdHere.inf
+++ b/VS2017ComCmdHere.inf
@@ -30,11 +30,11 @@ VS2017ComCmdHere.INF
 HKLM,%UDHERE%,DisplayName,,"%VS2017ComCmdHereName%"
 HKLM,%UDHERE%,UninstallString,,"rundll32.exe syssetup.dll,SetupInfObjectInstallAction DefaultUnInstall 132 %17%\VS2017ComCmdHere.inf"
 HKCR,Directory\Background\Shell\VS2017ComCmdHere,,,"%VS2017ComCmdHereAccel%"
-HKCR,Directory\Background\Shell\VS2017ComCmdHere\command,,,"%11%\cmd.exe /k cd ""%V"" && ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"""
+HKCR,Directory\Background\Shell\VS2017ComCmdHere\command,,,"cmd.exe /k call ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"" && pushd ""%V"""
 HKCR,Directory\Shell\VS2017ComCmdHere,,,"%VS2017ComCmdHereAccel%"
-HKCR,Directory\Shell\VS2017ComCmdHere\command,,,"%11%\cmd.exe /k cd ""%1"" && ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"""
+HKCR,Directory\Shell\VS2017ComCmdHere\command,,,"cmd.exe /k call ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"" && pushd ""%V"""
 HKCR,Drive\Shell\VS2017ComCmdHere,,,"%VS2017ComCmdHereAccel%"
-HKCR,Drive\Shell\VS2017ComCmdHere\command,,,"%11%\cmd.exe /k cd ""%1"" && ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"""
+HKCR,Drive\Shell\VS2017ComCmdHere\command,,,"cmd.exe /k call ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"" && pushd ""%1"""
 
 [VS2017ComCmdHereUninstall.Reg]
 HKLM,%UDHERE%

--- a/VS2017EntCmdHere.inf
+++ b/VS2017EntCmdHere.inf
@@ -30,11 +30,11 @@ VS2017EntCmdHere.INF
 HKLM,%UDHERE%,DisplayName,,"%VS2017EntCmdHereName%"
 HKLM,%UDHERE%,UninstallString,,"rundll32.exe syssetup.dll,SetupInfObjectInstallAction DefaultUnInstall 132 %17%\VS2017EntCmdHere.inf"
 HKCR,Directory\Background\Shell\VS2017EntCmdHere,,,"%VS2017EntCmdHereAccel%"
-HKCR,Directory\Background\Shell\VS2017EntCmdHere\command,,,"%11%\cmd.exe /k cd ""%V"" && ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"""
+HKCR,Directory\Background\Shell\VS2017EntCmdHere\command,,,"cmd.exe /k call ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"" && pushd ""%V"""
 HKCR,Directory\Shell\VS2017EntCmdHere,,,"%VS2017EntCmdHereAccel%"
-HKCR,Directory\Shell\VS2017EntCmdHere\command,,,"%11%\cmd.exe /k cd ""%1"" && ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"""
+HKCR,Directory\Shell\VS2017EntCmdHere\command,,,"cmd.exe /k call ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"" && pushd ""%V"""
 HKCR,Drive\Shell\VS2017EntCmdHere,,,"%VS2017EntCmdHereAccel%"
-HKCR,Drive\Shell\VS2017EntCmdHere\command,,,"%11%\cmd.exe /k cd ""%1"" && ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"""
+HKCR,Drive\Shell\VS2017EntCmdHere\command,,,"cmd.exe /k call ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"" && pushd ""%1"""
 
 [VS2017EntCmdHereUninstall.Reg]
 HKLM,%UDHERE%

--- a/VS2017ProCmdHere.inf
+++ b/VS2017ProCmdHere.inf
@@ -30,11 +30,11 @@ VS2017ProCmdHere.INF
 HKLM,%UDHERE%,DisplayName,,"%VS2017ProCmdHereName%"
 HKLM,%UDHERE%,UninstallString,,"rundll32.exe syssetup.dll,SetupInfObjectInstallAction DefaultUnInstall 132 %17%\VS2017ProCmdHere.inf"
 HKCR,Directory\Background\Shell\VS2017ProCmdHere,,,"%VS2017ProCmdHereAccel%"
-HKCR,Directory\Background\Shell\VS2017ProCmdHere\command,,,"%11%\cmd.exe /k cd ""%V"" && ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat"""
+HKCR,Directory\Background\Shell\VS2017ProCmdHere\command,,,"cmd.exe /k call ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat"" && pushd ""%V"""
 HKCR,Directory\Shell\VS2017ProCmdHere,,,"%VS2017ProCmdHereAccel%"
-HKCR,Directory\Shell\VS2017ProCmdHere\command,,,"%11%\cmd.exe /k cd ""%1"" && ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat"""
+HKCR,Directory\Shell\VS2017ProCmdHere\command,,,"cmd.exe /k call ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat"" && pushd ""%V"""
 HKCR,Drive\Shell\VS2017ProCmdHere,,,"%VS2017ProCmdHereAccel%"
-HKCR,Drive\Shell\VS2017ProCmdHere\command,,,"%11%\cmd.exe /k cd ""%1"" && ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat"""
+HKCR,Drive\Shell\VS2017ProCmdHere\command,,,"cmd.exe /k call ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat"" && pushd ""%1"""
 
 [VS2017ProCmdHereUninstall.Reg]
 HKLM,%UDHERE%


### PR DESCRIPTION
* cmd.exe doesn't need am absolute path specified
* CD wasn't working unless you were on the right drive to start with. PUSHD solves this, and if you're on a network share it maps a temp drive letter too.
* VsDevCmd.bat changes directory when it runs, so moved PUSHD to run last.

PS. I've only tested enterprise, but I've applied the same change to community and professional versions.